### PR TITLE
Add toggleTheme unit test

### DIFF
--- a/src/app/services/theme.service.spec.ts
+++ b/src/app/services/theme.service.spec.ts
@@ -2,16 +2,33 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ThemeService } from './theme.service';
+import { ConsentService } from './consent.service';
 
 describe('ThemeService', () => {
   let service: ThemeService;
+  let consentServiceMock: jasmine.SpyObj<ConsentService>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    consentServiceMock = jasmine.createSpyObj('ConsentService', ['hasConsent']);
+    consentServiceMock.hasConsent.and.returnValue(false);
+    TestBed.configureTestingModule({
+      providers: [{ provide: ConsentService, useValue: consentServiceMock }],
+    });
     service = TestBed.inject(ThemeService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should toggle theme and emit change', () => {
+    const initialTheme = service.currentTheme;
+    let emittedTheme: 'light' | 'dark' | undefined;
+    service.themeChanged.subscribe((theme) => (emittedTheme = theme));
+
+    service.toggleTheme();
+
+    expect(service.currentTheme).not.toBe(initialTheme);
+    expect(emittedTheme).toBe(service.currentTheme);
   });
 });


### PR DESCRIPTION
## Summary
- test ThemeService toggling behavior using EventEmitter

## Testing
- `npm run test` *(fails: `ng` not found)*
- `npx ng test --watch=false` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fffecdae08325ad9de05f92e60871