### PR TITLE
Add decline option to cookie consent banner

### DIFF
--- a/src/app/components/cookie-consent/cookie-consent.component.css
+++ b/src/app/components/cookie-consent/cookie-consent.component.css
@@ -79,15 +79,26 @@
       transform: scale(0.97);
   }
   
-  .accept-button {
-    background-color: var(--blue); /* Use theme blue */
-    color: #fff; /* Ensure contrast */
-  }
-  
-  .accept-button:hover {
-    /* Slightly darken the blue on hover - adjust if needed */
-    filter: brightness(0.9);
-  }
+.accept-button {
+  background-color: var(--blue); /* Use theme blue */
+  color: #fff; /* Ensure contrast */
+}
+
+.accept-button:hover {
+  /* Slightly darken the blue on hover - adjust if needed */
+  filter: brightness(0.9);
+}
+
+.decline-button {
+  background-color: var(--gray1);
+  color: var(--gray4);
+  border: 1px solid var(--gray2);
+  margin-right: 0.5rem;
+}
+
+.decline-button:hover {
+  background-color: var(--gray2);
+}
   
   /* Responsive adjustments */
   @media (max-width: 640px) { /* Adjust breakpoint if needed */

--- a/src/app/components/cookie-consent/cookie-consent.component.html
+++ b/src/app/components/cookie-consent/cookie-consent.component.html
@@ -4,6 +4,7 @@
         This website uses local storage to enhance your experience, primarily for saving theme preferences and external link warning settings (functional purposes). By clicking "Accept", you consent to this use.
         </p>
       <div class="consent-actions">
+        <button class="button decline-button" (click)="decline()">Decline</button>
         <button class="button accept-button" (click)="accept()">Accept</button>
       </div>
     </div>

--- a/src/app/components/cookie-consent/cookie-consent.component.ts
+++ b/src/app/components/cookie-consent/cookie-consent.component.ts
@@ -19,8 +19,10 @@ export class CookieConsentComponent {
     this.consentService.acceptConsent();
   }
 
-  // Optional: Implement decline logic if you add a decline button
-  // decline(): void {
-  //   this.consentService.declineConsent();
-  // }
+  /**
+   * Handle user declining consent.
+   */
+  decline(): void {
+    this.consentService.declineConsent();
+  }
 }


### PR DESCRIPTION
## Summary
- add decline method to `CookieConsentComponent`
- show a Decline button in the cookie consent banner
- style the new Decline button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684000c03eec832594625d459da9e690